### PR TITLE
[script]: fix path in hoedur docker run

### DIFF
--- a/run_experiment.py
+++ b/run_experiment.py
@@ -61,7 +61,7 @@ def run_hoedur_docker(cmd_args, max_cores, run_sync=False):
         "--rm",
         "--user", f"{os.getuid()}:{os.getgid()}",
         "--mount", f"src={DIR},target=/home/user/hoedur-experiments,type=bind",
-        "--mount", f"src={DIR}/targets,target=/home/user/hoedur-targets,type=bind",
+        "--mount", f"src={DIR}/targets,target=/hoedur-targets,type=bind",
         "-t",
         "hoedur-fuzzware"
     ]


### PR DESCRIPTION
Original implementation will skip all experiments because config.yml for targets is not in right place.

Consider change it like this pull request or change the hoedur run script or the docker image 

Test on my machine. Successfully run the experiments in docker parallel